### PR TITLE
Added Support for React Native Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ dependencies {
 iOS lib [fave-button](https://github.com/xhamr/fave-button) Android implement.
 FaveButton was inspired by Twitter’s Like Heart Animation;
 
+## Third Party Bindings
+  		  
+### React Native
+You may now use this library with [React Native](https://github.com/facebook/react-native) via the module [here](https://github.com/prscX/react-native-shine-button)
+
+
 License
 ------------
     The MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ FaveButton was inspired by Twitter’s Like Heart Animation;
 
 ## Third Party Bindings
   		  
-### React Native
+#### React Native
 You may now use this library with [React Native](https://github.com/facebook/react-native) via the module [here](https://github.com/prscX/react-native-shine-button)
 
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ FaveButton was inspired by Twitter’s Like Heart Animation;
 
 ## Third Party Bindings
   		  
-#### React Native
+### React Native
 You may now use this library with [React Native](https://github.com/facebook/react-native) via the module [here](https://github.com/prscX/react-native-shine-button)
 
 


### PR DESCRIPTION
Hi @ChadCSong 

First of all I would like to appreciate for creating such a nice, cool library

I have created a [React Native](https://github.com/facebook/react-native) bridge plugin for using this library with React Native projects

I have added the same in README. Can you please merge this request so that if someone is looking to use this library for React Native projects can easily do the same

Please let me know in case any changes are required

[react-native-shine-button](https://github.com/prscX/react-native-shine-button)

Thanks
Pranav