### PR TITLE
Enabling Support for Custom Icons

### DIFF
--- a/shinebuttonlib/src/main/java/com/sackcentury/shinebuttonlib/PorterShapeImageView.java
+++ b/shinebuttonlib/src/main/java/com/sackcentury/shinebuttonlib/PorterShapeImageView.java
@@ -38,7 +38,7 @@ public class PorterShapeImageView extends PorterImageView {
         matrix = new Matrix();
     }
 
-    void setShape(Drawable drawable) {
+    public void setShape(Drawable drawable) {
         shape = drawable;
         invalidate();
     }


### PR DESCRIPTION
Hi @ChadCSong,

This PR is w.r.t [react-native-shine-button: issue: 4](https://github.com/prscX/react-native-shine-button/issues/4). We have a requirement to support custom icons as well. Since drawables are within ReactNative context, it is hard to get drawable resource id.

In order to support this I have provided `public` access to `PorterShapeImageView.setShape` method.

Please find below the output I have received:

<img width="504" alt="screen shot 2018-04-01 at 4 15 45 pm" src="https://user-images.githubusercontent.com/28862892/38172361-a1076d02-35c8-11e8-95f3-bd5e34a6175b.png">

Can you please merge this PR. Please let me know in case any discussion is required for the same.

@afsadilson

Thanks
</ Pranav > 