### PR TITLE
removes conflicting configuration from AndroidManifest

### DIFF
--- a/shinebuttonlib/src/main/AndroidManifest.xml
+++ b/shinebuttonlib/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.sackcentury.shinebuttonlib">
+<manifest package="com.sackcentury.shinebuttonlib">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
+    <application>
     </application>
 
 </manifest>


### PR DESCRIPTION
Hey I just saw that the AndroidManifest of this lib seems to override quite some stuff which it doesn't need. This resolves to errors when using the lib and setting a label that is not `app_name`.

You can fix this error easily with `tools:replace="android:label"`, however I wanted to offer a little pull request to just remove it :)